### PR TITLE
Remove middle button click when left is triggered

### DIFF
--- a/SWICD/Services/KeyboardMouseInputMapper.cs
+++ b/SWICD/Services/KeyboardMouseInputMapper.cs
@@ -118,7 +118,6 @@ namespace SWICD.Services
             byte btns = 0;
             if (leftButton) { btns = 1; };
             if (rightButton) { btns = (byte)(btns | (1 << 1)); }
-            if (leftButton) { btns = (byte)(btns | (1 << 2)); }
             MouseRelData.Buttons = btns;  //button states are represented by the 3 least significant bits
             if (!ignoreMove)
             {


### PR DESCRIPTION
Stop registering a middle button click when left mouse button is triggered. 

Referencing the [Tetherscript dev guide](https://tetherscript.com/kbhid/hid-using-the-mouse-driver-rel/)
```
00000000 = no buttons pressed.
00000001 = only left button pressed.
00000010 = only right button pressed.
00000100 = only middle button pressed.
00000110 = only right and middle buttons pressed.
00000101 = only left and middle buttons pressed.
00000111 = all buttons pressed.
```
This should fix https://github.com/mKenfenheuer/steam-deck-windows-usermode-driver/issues/66 and https://github.com/mKenfenheuer/steam-deck-windows-usermode-driver/issues/62