### PR TITLE
Add Rumble Toggle to Button Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Steamdeck Windows Controller Driver
+This forks adds new features to original SWICD and also fixes some bugs. Once tested, I will create a pull request to the main repos and hope the author to accept the new features.
 **S**teamdeck **WI**ndows **C**ontroller **D**river (SWICD)
+
 
 This work-in-progress driver maps the Steam deck's built-in controller to a virtual ViGEm XBox 360 Controller. The layout is customizeable using the gui.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Steamdeck Windows Controller Driver
-This forks adds new features to original SWICD and also fixes some bugs. Once tested, I will create a pull request to the main repos and hope the author to accept the new features.
 **S**teamdeck **WI**ndows **C**ontroller **D**river (SWICD)
-
 
 This work-in-progress driver maps the Steam deck's built-in controller to a virtual ViGEm XBox 360 Controller. The layout is customizeable using the gui.
 

--- a/SWICD/Config/ProfileSettings.cs
+++ b/SWICD/Config/ProfileSettings.cs
@@ -21,9 +21,15 @@ namespace SWICD.Config
         public bool ToggleInvertLizardButtons { get; set; }
 
         [JsonIgnore]
+        public bool ToggleInvertHaptics { get; set; }
+
+        [JsonIgnore]
         public bool ToggledDisableLizardMouse => ToggleInvertLizardMode && !DisableLizardMouse ? !DisableLizardMouse : DisableLizardMouse;
         [JsonIgnore]
         public bool ToggledDisableLizardButtons => ToggleInvertLizardButtons && !DisableLizardButtons ? !DisableLizardButtons : DisableLizardButtons;
+
+        [JsonIgnore]
+        public bool ToggledDisableHaptics => ToggleInvertHaptics && HapticFeedbackEnabled ? HapticFeedbackEnabled : !HapticFeedbackEnabled;
 
         public bool GetInvertedEmulationEnabled(bool enabled) => ToggleInvertEmulationActive ? !enabled : enabled;
 

--- a/SWICD/Model/ButtonActionModel.cs
+++ b/SWICD/Model/ButtonActionModel.cs
@@ -24,6 +24,8 @@ namespace SWICD.Model
                 {
                     case "keyboard-shortcut":
                         return ButtonAction.Data;
+                    case "toggle-haptics":
+                        return "Toggle Controller Rumble";
                     case "toggle-lizardmode":
                         return "Toggle Mouse Lizardmode";
                     case "toggle-lizardbuttons":

--- a/SWICD/Pages/EditButtonActionWindow.xaml
+++ b/SWICD/Pages/EditButtonActionWindow.xaml
@@ -35,6 +35,7 @@
             <RowDefinition Height="50" />
             <RowDefinition Height="50" />
             <RowDefinition Height="50" />
+            <RowDefinition Height="50" />
             <RowDefinition />
         </Grid.RowDefinitions>
 
@@ -153,13 +154,21 @@
                      Content="Toggle Emulation on/off"
                      Grid.Row="2"
                      Grid.Column="1" />
+        
+        <RadioButton GroupName="action"
+                     Foreground="#fff"
+                     VerticalAlignment="Center"
+                     IsChecked="{Binding IsHapticsToggle, Mode=TwoWay}"
+                     Content="Toggle Controller Rumble on/off"
+                     Grid.Row="3"
+                     Grid.Column="1" />
 
         <RadioButton GroupName="action"
                      Foreground="#fff"
                      VerticalAlignment="Center"
                      IsChecked="{Binding IsLizardToggle, Mode=TwoWay}"
                      Content="Toggle Mouse Lizard Mode on/off"
-                     Grid.Row="3"
+                     Grid.Row="4"
                      Grid.Column="1" />
 
         <RadioButton GroupName="action"
@@ -167,7 +176,7 @@
                      VerticalAlignment="Center"
                      IsChecked="{Binding IsLizardButtonsToggle, Mode=TwoWay}"
                      Content="Toggle Buttons Lizard Mode on/off"
-                     Grid.Row="4"
+                     Grid.Row="5"
                      Grid.Column="1" />
 
         <RadioButton GroupName="action"
@@ -175,7 +184,7 @@
                      VerticalAlignment="Center"
                      IsChecked="{Binding IsLizardButtonsMouseToggle, Mode=TwoWay}"
                      Content="Toggle Buttons and Mouse Lizard Mode on/off"
-                     Grid.Row="5"
+                     Grid.Row="6"
                      Grid.Column="1" />
 
         <RadioButton GroupName="action"
@@ -183,7 +192,7 @@
                      VerticalAlignment="Center"
                      IsChecked="{Binding IsLizardEmulationToggle, Mode=TwoWay}"
                      Content="Toggle Lizard Mode and Emulation on/off"
-                     Grid.Row="6"
+                     Grid.Row="7"
                      Grid.Column="1" />
 
         <RadioButton GroupName="action"
@@ -191,12 +200,12 @@
                      VerticalAlignment="Center"
                      IsChecked="{Binding IsKeyboardAction, Mode=TwoWay}"
                      Content="Keyboard Shortcut"
-                     Grid.Row="7"
+                     Grid.Row="8"
                      Grid.Column="1" />
 
         <Label Foreground="#fff"
                FontWeight="SemiBold"
-               Grid.Row="8" 
+               Grid.Row="9" 
                Grid.Column="1" 
                Grid.ColumnSpan="1"
                VerticalAlignment="Center"
@@ -206,7 +215,7 @@
 
         <ComboBox
                 Grid.Column="2"
-                Grid.Row="8"
+                Grid.Row="9"
                 Grid.ColumnSpan="1"
                 FontFamily="{DynamicResource PromptFont}"
                 FontSize="30"
@@ -215,7 +224,7 @@
                 ItemsSource="{Binding KeyboardItems}"/>
 
         <Button
-            Grid.Row="8"
+            Grid.Row="9"
             Grid.Column="3"
             HorizontalContentAlignment="Left"
             Foreground="#fff"
@@ -248,7 +257,7 @@
             </Button.Content>
         </Button>
         <Button
-            Grid.Row="8"
+            Grid.Row="9"
             Grid.Column="4"
             HorizontalContentAlignment="Left"
             Foreground="#fff"

--- a/SWICD/Services/ButtonActionsProcessor.cs
+++ b/SWICD/Services/ButtonActionsProcessor.cs
@@ -25,6 +25,9 @@ namespace SWICD.Services
                             case "keyboard-shortcut":
                                 ControllerService.Instance.KeyboardMouseInputMapper.ExecuteKeyboardAction(buttonAction.Data);
                                 break;
+                            case "toggle-haptics":
+                                currentConfig.ProfileSettings.ToggleInvertHaptics = !currentConfig.ProfileSettings.ToggleInvertHaptics;
+                                break;
                             case "toggle-lizardmode":
                                 currentConfig.ProfileSettings.ToggleInvertLizardMode = !currentConfig.ProfileSettings.ToggleInvertLizardMode;
                                 break;

--- a/SWICD/Services/ControllerService.cs
+++ b/SWICD/Services/ControllerService.cs
@@ -21,6 +21,7 @@ namespace SWICD.Services
         public string DecisionExecutable { get; private set; }
         public bool LizardMouseEnabled { get => _neptuneController.LizardMouseEnabled; private set => _neptuneController.LizardMouseEnabled = value; }
         public bool LizardButtonsEnabled { get => _neptuneController.LizardButtonsEnabled; private set => _neptuneController.LizardButtonsEnabled = value; }
+        public bool HapticsEnabled { get; private set; }
         public bool Started { get; private set; }
         public Configuration Configuration { get; internal set; }
 
@@ -92,7 +93,7 @@ namespace SWICD.Services
 
             byte amplitude = 0, period = 0;
 
-            if(profile.ProfileSettings.HapticFeedbackEnabled)
+            if(profile.ProfileSettings.HapticFeedbackEnabled && HapticsEnabled)
             {
                 amplitude = profile.ProfileSettings.HapticFeedbackAmplitude;
                 period = profile.ProfileSettings.HapticFeedbackPeriod;
@@ -204,6 +205,11 @@ namespace SWICD.Services
                 {
                     LizardButtonsEnabled = !_currentControllerConfig.ProfileSettings.ToggledDisableLizardButtons;
                     LoggingService.LogDebug($"LizardButtonsEnabled changed to: {LizardButtonsEnabled}");
+                }
+                if (HapticsEnabled != !_currentControllerConfig.ProfileSettings.ToggledDisableHaptics)
+                {
+                    HapticsEnabled = !_currentControllerConfig.ProfileSettings.ToggledDisableHaptics;
+                    LoggingService.LogDebug($"Controller Rumble changed to: {HapticsEnabled}");
                 }
             }
             catch (Exception ex)

--- a/SWICD/ViewModels/EditButtonActionWindowViewModel.cs
+++ b/SWICD/ViewModels/EditButtonActionWindowViewModel.cs
@@ -54,6 +54,24 @@ namespace SWICD.ViewModels
                     Type = "keyboard-shortcut";
                 NotifyPropertyChanged(nameof(Type));
                 NotifyPropertyChanged(nameof(IsKeyboardAction));
+                NotifyPropertyChanged(nameof(IsHapticsToggle));
+                NotifyPropertyChanged(nameof(IsLizardToggle));
+                NotifyPropertyChanged(nameof(IsLizardButtonsToggle));
+                NotifyPropertyChanged(nameof(IsLizardButtonsMouseToggle));
+                NotifyPropertyChanged(nameof(IsEmulationToggle));
+                NotifyPropertyChanged(nameof(IsLizardEmulationToggle));
+            }
+        }
+        public bool IsHapticsToggle
+        {
+            get => Type == "toggle-haptics";
+            set
+            {
+                if (value)
+                    Type = "toggle-haptics";
+                NotifyPropertyChanged(nameof(Type));
+                NotifyPropertyChanged(nameof(IsKeyboardAction));
+                NotifyPropertyChanged(nameof(IsHapticsToggle));
                 NotifyPropertyChanged(nameof(IsLizardToggle));
                 NotifyPropertyChanged(nameof(IsLizardButtonsToggle));
                 NotifyPropertyChanged(nameof(IsLizardButtonsMouseToggle));
@@ -70,6 +88,7 @@ namespace SWICD.ViewModels
                     Type = "toggle-lizardmode";
                 NotifyPropertyChanged(nameof(Type));
                 NotifyPropertyChanged(nameof(IsKeyboardAction));
+                NotifyPropertyChanged(nameof(IsHapticsToggle));
                 NotifyPropertyChanged(nameof(IsLizardToggle));
                 NotifyPropertyChanged(nameof(IsLizardButtonsToggle));
                 NotifyPropertyChanged(nameof(IsLizardButtonsMouseToggle));
@@ -86,6 +105,7 @@ namespace SWICD.ViewModels
                     Type = "toggle-lizardbuttons";
                 NotifyPropertyChanged(nameof(Type));
                 NotifyPropertyChanged(nameof(IsKeyboardAction));
+                NotifyPropertyChanged(nameof(IsHapticsToggle));
                 NotifyPropertyChanged(nameof(IsLizardToggle));
                 NotifyPropertyChanged(nameof(IsLizardButtonsToggle));
                 NotifyPropertyChanged(nameof(IsLizardButtonsMouseToggle));
@@ -102,6 +122,7 @@ namespace SWICD.ViewModels
                     Type = "toggle-lizardbuttons+mouse";
                 NotifyPropertyChanged(nameof(Type));
                 NotifyPropertyChanged(nameof(IsKeyboardAction));
+                NotifyPropertyChanged(nameof(IsHapticsToggle));
                 NotifyPropertyChanged(nameof(IsLizardToggle));
                 NotifyPropertyChanged(nameof(IsLizardButtonsToggle));
                 NotifyPropertyChanged(nameof(IsLizardButtonsMouseToggle));
@@ -118,6 +139,7 @@ namespace SWICD.ViewModels
                     Type = "toggle-emulation";
                 NotifyPropertyChanged(nameof(Type));
                 NotifyPropertyChanged(nameof(IsKeyboardAction));
+                NotifyPropertyChanged(nameof(IsHapticsToggle));
                 NotifyPropertyChanged(nameof(IsLizardToggle));
                 NotifyPropertyChanged(nameof(IsLizardButtonsToggle));
                 NotifyPropertyChanged(nameof(IsLizardButtonsMouseToggle));
@@ -132,6 +154,7 @@ namespace SWICD.ViewModels
             {
                 if (value)
                     Type = "toggle-lizardmode+emulation";
+                NotifyPropertyChanged(nameof(IsHapticsToggle));
                 NotifyPropertyChanged(nameof(IsLizardToggle));
                 NotifyPropertyChanged(nameof(IsLizardButtonsToggle));
                 NotifyPropertyChanged(nameof(IsLizardButtonsMouseToggle));


### PR DESCRIPTION
We have mouse & buttons lizardmode toggle, why not rumble too? Rumble (haptics) produce quite a bit of noise when you need to stay quiet, and turning it off in SWICD profile settings is cumbersome. This commit adds a new rumble (haptics) toggle option to Button Actions. Note that the toggling action only works when you enable haptics by checking the box.