### PR TITLE
Add axis-to-keyboard mapping support for controller axes

### DIFF
--- a/SWICD/Config/AxisKeyboardConfig.cs
+++ b/SWICD/Config/AxisKeyboardConfig.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace SWICD.Config
+{
+    [Serializable]
+    public class AxisKeyboardConfig : ICloneable, ISerializable
+    {
+        private string _positiveKey;
+        public string PositiveKey { get => _positiveKey; set => _positiveKey = value; }
+
+        private string _negativeKey;
+        public string NegativeKey { get => _negativeKey; set => _negativeKey = value; }
+
+        public AxisKeyboardConfig(string positiveKey, string negativeKey)
+        {
+            PositiveKey = positiveKey;
+            NegativeKey = negativeKey;
+        }
+
+        public AxisKeyboardConfig()
+        {
+            PositiveKey = "NONE";
+            NegativeKey = "NONE";
+        }
+
+        public AxisKeyboardConfig(SerializationInfo info, StreamingContext context)
+        {
+            PositiveKey = info.GetString("PositiveKey");
+            NegativeKey = info.GetString("NegativeKey");
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is AxisKeyboardConfig config &&
+                   _positiveKey == config._positiveKey &&
+                   _negativeKey == config._negativeKey;
+        }
+
+        public object Clone()
+        {
+            return new AxisKeyboardConfig(_positiveKey, _negativeKey);
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue("PositiveKey", _positiveKey);
+            info.AddValue("NegativeKey", _negativeKey);
+        }
+    }
+}

--- a/SWICD/Config/AxisKeyboardMapping.cs
+++ b/SWICD/Config/AxisKeyboardMapping.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace SWICD.Config
+{
+    [Serializable]
+    public class AxisKeyboardMapping : ICloneable, ISerializable
+    {
+        private Dictionary<HardwareAxis, AxisKeyboardConfig> _mappings = new Dictionary<HardwareAxis, AxisKeyboardConfig>()
+        {
+            { HardwareAxis.LeftStickX, new AxisKeyboardConfig() },
+            { HardwareAxis.LeftStickY, new AxisKeyboardConfig() },
+            { HardwareAxis.RightStickX, new AxisKeyboardConfig() },
+            { HardwareAxis.RightStickY, new AxisKeyboardConfig() },
+            { HardwareAxis.LeftPadX, new AxisKeyboardConfig() },
+            { HardwareAxis.LeftPadY, new AxisKeyboardConfig() },
+            { HardwareAxis.RightPadX, new AxisKeyboardConfig() },
+            { HardwareAxis.RightPadY, new AxisKeyboardConfig() },
+            { HardwareAxis.LeftPadPressure, new AxisKeyboardConfig() },
+            { HardwareAxis.RightPadPressure, new AxisKeyboardConfig() },
+            { HardwareAxis.L2, new AxisKeyboardConfig() },
+            { HardwareAxis.R2, new AxisKeyboardConfig() },
+            { HardwareAxis.GyroAccelX, new AxisKeyboardConfig() },
+            { HardwareAxis.GyroAccelY, new AxisKeyboardConfig() },
+            { HardwareAxis.GyroAccelZ, new AxisKeyboardConfig() },
+            { HardwareAxis.GyroRoll, new AxisKeyboardConfig() },
+            { HardwareAxis.GyroPitch, new AxisKeyboardConfig() },
+            { HardwareAxis.GyroYaw, new AxisKeyboardConfig() },
+        };
+
+        public AxisKeyboardMapping(Dictionary<HardwareAxis, AxisKeyboardConfig> mappings)
+        {
+            _mappings = mappings;
+        }
+
+        public AxisKeyboardMapping()
+        {
+        }
+
+        public AxisKeyboardMapping(SerializationInfo info, StreamingContext context)
+        {
+            var axes = _mappings.Keys.ToArray();
+            foreach (var axis in axes)
+            {
+                _mappings[axis] = (AxisKeyboardConfig)info.GetValue(axis.ToString(), typeof(AxisKeyboardConfig));
+            }
+        }
+
+        public AxisKeyboardConfig this[HardwareAxis axis]
+        {
+            get
+            {
+                if (_mappings.ContainsKey(axis))
+                    return _mappings[axis];
+                return new AxisKeyboardConfig();
+            }
+            set
+            {
+                _mappings[axis] = value;
+            }
+        }
+
+        public object Clone()
+        {
+            var clone = new AxisKeyboardMapping(_mappings.ToDictionary(entry => entry.Key,
+                                               entry => (AxisKeyboardConfig)entry.Value.Clone()));
+            return clone;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is AxisKeyboardMapping mapping &&
+                   _mappings.EqualsWithValues(mapping._mappings);
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            foreach (var axis in _mappings.Keys)
+            {
+                info.AddValue(axis.ToString(), _mappings[axis]);
+            }
+        }
+    }
+}

--- a/SWICD/Config/ControllerConfig.cs
+++ b/SWICD/Config/ControllerConfig.cs
@@ -11,6 +11,7 @@ namespace SWICD.Config
         public ButtonMapping ButtonMapping { get; set; } = new ButtonMapping();
         public AxisMapping AxisMapping { get; set; } = new AxisMapping();
         public KeyboardMapping KeyboardMapping { get; set; } = new KeyboardMapping();
+        public AxisKeyboardMapping AxisKeyboardMapping { get; set; } = new AxisKeyboardMapping();
         public MouseMapping MouseMapping { get; set; } = new MouseMapping();
 
         public ControllerConfig()
@@ -35,6 +36,7 @@ namespace SWICD.Config
             clone.ButtonMapping = (ButtonMapping)ButtonMapping.Clone();
             clone.AxisMapping = (AxisMapping)AxisMapping.Clone();
             clone.KeyboardMapping = (KeyboardMapping)KeyboardMapping.Clone();
+            clone.AxisKeyboardMapping = (AxisKeyboardMapping)AxisKeyboardMapping.Clone();
             clone.MouseMapping = (MouseMapping)MouseMapping.Clone();
             return clone;
         }
@@ -46,6 +48,7 @@ namespace SWICD.Config
                    EqualityComparer<ProfileSettings>.Default.Equals(ProfileSettings, config.ProfileSettings) &&
                    EqualityComparer<ButtonMapping>.Default.Equals(ButtonMapping, config.ButtonMapping) &&
                    EqualityComparer<KeyboardMapping>.Default.Equals(KeyboardMapping, config.KeyboardMapping) &&
+                   EqualityComparer<AxisKeyboardMapping>.Default.Equals(AxisKeyboardMapping, config.AxisKeyboardMapping) &&
                    EqualityComparer<MouseMapping>.Default.Equals(MouseMapping, config.MouseMapping) &&
                    EqualityComparer<AxisMapping>.Default.Equals(AxisMapping, config.AxisMapping);
         }

--- a/SWICD/Model/AxisKeyboardMappingModel.cs
+++ b/SWICD/Model/AxisKeyboardMappingModel.cs
@@ -1,0 +1,76 @@
+using SWICD.Services;
+using SWICD.Config;
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text.RegularExpressions;
+using SWICD.HVDK;
+
+namespace SWICD.Model
+{
+    internal class AxisKeyboardMappingModel
+    {
+        private EnumComboBoxItem<string> _selectedPositiveKey;
+        private EnumComboBoxItem<string> _selectedNegativeKey;
+
+        public ObservableCollection<EnumComboBoxItem<string>> KeyboardItems { get; set; } = new ObservableCollection<EnumComboBoxItem<string>>(new string[] { "NONE" }.Concat(new KeyboardUtils().GetAvailableKeysWithModifiers).Select(e => new EnumComboBoxItem<string>()
+        {
+            Value = e,
+            Display = FontEnumMapper.MapEmulatedKeyboardKeyToFont(e),
+        }));
+
+        public string AxisText => Regex.Replace(FontEnumMapper.MapHardwareAxisToFont(HardwareAxis), "([^A-Z])([A-Z])", "$1 $2");
+        public HardwareAxis HardwareAxis { get; set; }
+
+        public EnumComboBoxItem<string> SelectedPositiveKey
+        {
+            get => _selectedPositiveKey;
+            set
+            {
+                _selectedPositiveKey = value;
+                if (SetPositiveKeyAction != null)
+                    SetPositiveKeyAction(value.Value);
+            }
+        }
+
+        public EnumComboBoxItem<string> SelectedNegativeKey
+        {
+            get => _selectedNegativeKey;
+            set
+            {
+                _selectedNegativeKey = value;
+                if (SetNegativeKeyAction != null)
+                    SetNegativeKeyAction(value.Value);
+            }
+        }
+
+        public Action<string> SetPositiveKeyAction { get; set; }
+        public Action<string> SetNegativeKeyAction { get; set; }
+
+        public string PositiveKey
+        {
+            get => SelectedPositiveKey.Value;
+            set
+            {
+                SelectedPositiveKey = new EnumComboBoxItem<string>()
+                {
+                    Value = value,
+                    Display = FontEnumMapper.MapEmulatedKeyboardKeyToFont(value),
+                };
+            }
+        }
+
+        public string NegativeKey
+        {
+            get => SelectedNegativeKey.Value;
+            set
+            {
+                SelectedNegativeKey = new EnumComboBoxItem<string>()
+                {
+                    Value = value,
+                    Display = FontEnumMapper.MapEmulatedKeyboardKeyToFont(value),
+                };
+            }
+        }
+    }
+}

--- a/SWICD/Pages/ProfileEditPage.xaml
+++ b/SWICD/Pages/ProfileEditPage.xaml
@@ -485,6 +485,119 @@
                     </ListView>
                 </Grid>
             </TabItem>
+            <TabItem Header="Axis Keyboard Mappings"
+                    FontSize="12"
+                    Foreground="#fff">
+                <Grid
+                      Background="#2c2c2c">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="240"/>
+                        <ColumnDefinition Width="1"/>
+                        <ColumnDefinition />
+                        <ColumnDefinition />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="30" />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+
+                    <Label Content="Hardware Axis"
+                           Foreground="#fff"
+                           FontSize="14"
+                           Grid.Column="0"
+                           Grid.ColumnSpan="2"
+                           FontWeight="SemiBold"/>
+
+                    <Label Content="Positive Key"
+                           Grid.Column="2"
+                           Foreground="#fff"
+                           FontSize="14"
+                           FontWeight="SemiBold"/>
+
+                    <Label Content="Negative Key"
+                           Grid.Column="3"
+                           Foreground="#fff"
+                           FontSize="14"
+                           FontWeight="SemiBold"/>
+
+                    <ListView Panel.ZIndex="0"
+                            Grid.Row="1"
+                            Foreground="#fff"
+                            Grid.Column="0"
+                            Grid.ColumnSpan="4"
+                            BorderThickness="0"
+                            Background="#2c2c2c"
+                            ItemsSource="{Binding AxisKeyboardMappings}"
+                            HorizontalContentAlignment="Stretch">
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="{x:Type ListViewItem}">
+                                <Setter Property="Background" Value="Transparent"/>
+                                <Setter Property="BorderThickness" Value="0" />
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="{x:Type ListViewItem}">
+                                            <Border Background="{TemplateBinding Background}"
+                                                BorderBrush="{TemplateBinding BorderBrush}"
+                                                BorderThickness="{TemplateBinding BorderThickness}">
+                                                <ContentPresenter x:Name="PART_Content"
+                                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                TextElement.Foreground="{TemplateBinding Foreground}"></ContentPresenter>
+                                            </Border>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                                <Style.Triggers>
+                                    <Trigger Property="IsMouseOver" Value="True">
+                                        <Setter Property="Background" Value="#ff2c2c2c"/>
+                                    </Trigger>
+                                    <Trigger Property="IsSelected" Value="True">
+                                        <Setter Property="Background" Value="#ff282828"/>
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ListView.ItemContainerStyle>
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="240"/>
+                                        <ColumnDefinition Width="1"/>
+                                        <ColumnDefinition />
+                                        <ColumnDefinition />
+                                    </Grid.ColumnDefinitions>
+
+                                    <Label Content="{Binding AxisText}"
+                                            Foreground="#fff"
+                                            Grid.Column="0"
+                                            Grid.ColumnSpan="2"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center"
+                                            FontFamily="{DynamicResource PromptFont}"
+                                            FontSize="30" />
+
+                                    <ComboBox
+                                        Grid.Column="2"
+                                        FontSize="30"
+                                        FontFamily="{DynamicResource PromptFont}"
+                                        VerticalContentAlignment="Center"
+                                        SelectedItem="{Binding SelectedPositiveKey}"
+                                        ItemsSource="{Binding KeyboardItems}" />
+
+                                    <ComboBox
+                                        Grid.Column="3"
+                                        Margin="5,0,0,0"
+                                        FontSize="30"
+                                        FontFamily="{DynamicResource PromptFont}"
+                                        VerticalContentAlignment="Center"
+                                        SelectedItem="{Binding SelectedNegativeKey}"
+                                        ItemsSource="{Binding KeyboardItems}" />
+                                </Grid>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </Grid>
+            </TabItem>
             <TabItem Header="Mouse Mappings"
                     FontSize="12"
                     Foreground="#fff">

--- a/SWICD/Services/KeyboardMouseInputMapper.cs
+++ b/SWICD/Services/KeyboardMouseInputMapper.cs
@@ -16,6 +16,8 @@ namespace SWICD.Services
 {
     internal class KeyboardMouseInputMapper
     {
+        private const short AxisKeyboardThreshold = short.MaxValue / 2;
+
         private HIDController _mouseHidController = new HIDController();
         private HIDController _keyboardHidController = new HIDController();
         private KeyboardUtils _keyboardUtils = new KeyboardUtils();
@@ -24,6 +26,9 @@ namespace SWICD.Services
 
         private bool LastLeftMouseButtonState = false;
         private bool LastRightMouseButtonState = false;
+
+        private Dictionary<HardwareAxis, bool> _lastAxisPositiveState = new Dictionary<HardwareAxis, bool>();
+        private Dictionary<HardwareAxis, bool> _lastAxisNegativeState = new Dictionary<HardwareAxis, bool>();
 
         public KeyboardMouseInputMapper()
         {
@@ -247,6 +252,36 @@ namespace SWICD.Services
             LastRightMouseButtonState = rightMouse;
         }
 
+        private void AddKeyToReport(string key, ref byte modifiers, List<byte> pressedKeys)
+        {
+            if (key == null || key == String.Empty || key == "NONE")
+                return;
+
+            if (key.StartsWith("["))
+            {
+                int bit = _keyboardUtils.GetModifierKeyCode(key);
+                byte m1;
+                switch (bit)
+                {
+                    case 0: m1 = 1; break;
+                    case 1: m1 = 2; break;
+                    case 2: m1 = 4; break;
+                    case 3: m1 = 8; break;
+                    case 4: m1 = 16; break;
+                    case 5: m1 = 32; break;
+                    case 6: m1 = 64; break;
+                    case 7: m1 = 128; break;
+                    default: m1 = 0; break;
+                }
+                modifiers = (byte)(modifiers | m1);
+            }
+            else
+            {
+                if (pressedKeys.Count() < 6)
+                    pressedKeys.Add(_keyboardUtils.GetKeyKeyCode(key));
+            }
+        }
+
         public void MapKeyboardInput(ControllerConfig config, NeptuneControllerInputState input)
         {
             if ((DateTime.UtcNow - _lastPing).TotalMilliseconds > 200)
@@ -255,53 +290,67 @@ namespace SWICD.Services
                 _lastPing = DateTime.UtcNow;
             }
 
-            if (_lastState != null)
+            // Determine current axis threshold states
+            bool axisStateChanged = false;
+            Dictionary<HardwareAxis, bool> currentAxisPositive = new Dictionary<HardwareAxis, bool>();
+            Dictionary<HardwareAxis, bool> currentAxisNegative = new Dictionary<HardwareAxis, bool>();
+
+            foreach (var axis in input.AxesState.Axes)
             {
-                if (!_lastState.ButtonState.Equals(input.ButtonState))
+                var axisConfig = config.AxisKeyboardMapping[(HardwareAxis)axis];
+                bool positiveActive = false;
+                bool negativeActive = false;
+
+                if (axisConfig.PositiveKey != "NONE" || axisConfig.NegativeKey != "NONE")
                 {
-                    _lastState = input;
-                    List<byte> pressedKeys = new List<byte>();
-                    byte modifiers = 0;
-
-                    foreach (var btn in input.ButtonState.Buttons)
-                        if (config.KeyboardMapping[(HardwareButton)btn] != null &&
-                            config.KeyboardMapping[(HardwareButton)btn] != String.Empty &&
-                            input.ButtonState[btn])
-                        {
-                            var key = config.KeyboardMapping[(HardwareButton)btn];
-
-                            if (key == "NONE")
-                                continue;
-
-                            if (key.StartsWith("["))
-                            {
-                                int bit = _keyboardUtils.GetModifierKeyCode(key);
-                                byte m1;
-                                switch (bit)
-                                {
-                                    case 0: m1 = 1; break;
-                                    case 1: m1 = 2; break;
-                                    case 2: m1 = 4; break;
-                                    case 3: m1 = 8; break;
-                                    case 4: m1 = 16; break;
-                                    case 5: m1 = 32; break;
-                                    case 6: m1 = 64; break;
-                                    case 7: m1 = 128; break;
-                                    default: m1 = 0; break;
-                                }
-                                modifiers = (byte)(modifiers | m1);
-                            }
-                            else
-                            {
-                                if (pressedKeys.Count() < 6)
-                                    pressedKeys.Add(_keyboardUtils.GetKeyKeyCode(key));
-                            }
-                        }
-
-                    SendKeyboardData(modifiers, pressedKeys);
+                    short value = input.AxesState[axis];
+                    positiveActive = value > AxisKeyboardThreshold;
+                    negativeActive = value < -AxisKeyboardThreshold;
                 }
+
+                currentAxisPositive[(HardwareAxis)axis] = positiveActive;
+                currentAxisNegative[(HardwareAxis)axis] = negativeActive;
+
+                bool lastPositive = _lastAxisPositiveState.ContainsKey((HardwareAxis)axis) && _lastAxisPositiveState[(HardwareAxis)axis];
+                bool lastNegative = _lastAxisNegativeState.ContainsKey((HardwareAxis)axis) && _lastAxisNegativeState[(HardwareAxis)axis];
+
+                if (positiveActive != lastPositive || negativeActive != lastNegative)
+                    axisStateChanged = true;
             }
 
+            bool buttonStateChanged = _lastState != null && !_lastState.ButtonState.Equals(input.ButtonState);
+
+            if (_lastState != null && (buttonStateChanged || axisStateChanged))
+            {
+                List<byte> pressedKeys = new List<byte>();
+                byte modifiers = 0;
+
+                // Collect keys from button mappings
+                foreach (var btn in input.ButtonState.Buttons)
+                    if (config.KeyboardMapping[(HardwareButton)btn] != null &&
+                        config.KeyboardMapping[(HardwareButton)btn] != String.Empty &&
+                        input.ButtonState[btn])
+                    {
+                        AddKeyToReport(config.KeyboardMapping[(HardwareButton)btn], ref modifiers, pressedKeys);
+                    }
+
+                // Collect keys from axis keyboard mappings
+                foreach (var axis in input.AxesState.Axes)
+                {
+                    var axisConfig = config.AxisKeyboardMapping[(HardwareAxis)axis];
+
+                    if (currentAxisPositive[(HardwareAxis)axis])
+                        AddKeyToReport(axisConfig.PositiveKey, ref modifiers, pressedKeys);
+
+                    if (currentAxisNegative[(HardwareAxis)axis])
+                        AddKeyToReport(axisConfig.NegativeKey, ref modifiers, pressedKeys);
+                }
+
+                SendKeyboardData(modifiers, pressedKeys);
+            }
+
+            _lastAxisPositiveState = currentAxisPositive;
+            _lastAxisNegativeState = currentAxisNegative;
             _lastState = input;
         }
     }

--- a/SWICD/ViewModels/ProfileEditPageViewModel.cs
+++ b/SWICD/ViewModels/ProfileEditPageViewModel.cs
@@ -21,6 +21,7 @@ namespace SWICD.ViewModels
         public ObservableCollection<MouseMappingModel> MouseMappings { get; set; } = new ObservableCollection<MouseMappingModel>();
         public ObservableCollection<ButtonMappingModel> ButtonMappings { get; set; } = new ObservableCollection<ButtonMappingModel>();
         public ObservableCollection<AxisMappingModel> AxisMappings { get; set; } = new ObservableCollection<AxisMappingModel>();
+        public ObservableCollection<AxisKeyboardMappingModel> AxisKeyboardMappings { get; set; } = new ObservableCollection<AxisKeyboardMappingModel>();
 
         public Visibility DeleteButtonVisible => Executable != null ? Visibility.Visible : Visibility.Hidden;
         public CommandHandler DeleteButtonClickCommand => new CommandHandler((obj) => OnDeleteButtonClick());
@@ -151,6 +152,17 @@ namespace SWICD.ViewModels
                         Inverted = ControllerConfig.AxisMapping[axis].Inverted,
                         SetAxisAction = val => ControllerConfig.AxisMapping[axis].EmulatedAxis = val,
                         SetActivationButtonAction = val => ControllerConfig.AxisMapping[axis].ActivationButton = val,
+                    });
+
+            foreach (HardwareAxis axis in Enum.GetValues(typeof(HardwareAxis)))
+                if (axis != HardwareAxis.None)
+                    AxisKeyboardMappings.Add(new AxisKeyboardMappingModel()
+                    {
+                        HardwareAxis = axis,
+                        PositiveKey = ControllerConfig.AxisKeyboardMapping[axis].PositiveKey,
+                        NegativeKey = ControllerConfig.AxisKeyboardMapping[axis].NegativeKey,
+                        SetPositiveKeyAction = val => ControllerConfig.AxisKeyboardMapping[axis].PositiveKey = val,
+                        SetNegativeKeyAction = val => ControllerConfig.AxisKeyboardMapping[axis].NegativeKey = val,
                     });
         }
         public void NotifyPropertyChanged(string propName)


### PR DESCRIPTION
## Summary
This PR introduces a new feature that allows mapping hardware controller axes to keyboard keys, enabling users to control keyboard input through analog stick and trigger movements.

## Key Changes
- **New Config Classes**: Added `AxisKeyboardConfig` and `AxisKeyboardMapping` classes to manage axis-to-keyboard mappings with serialization support
- **Model Layer**: Created `AxisKeyboardMappingModel` to handle UI binding for axis keyboard mappings with positive/negative key selection
- **Controller Config**: Integrated `AxisKeyboardMapping` into `ControllerConfig` with proper cloning and equality comparison
- **UI Tab**: Added new "Axis Keyboard Mappings" tab in ProfileEditPage with ListView displaying all hardware axes and their mapped positive/negative keyboard keys
- **Code Formatting**: Fixed whitespace inconsistencies in ProfileEditPage.xaml for consistency

## Implementation Details
- Each hardware axis can be mapped to two keyboard keys: one for positive direction and one for negative direction
- The mapping system supports all 18 hardware axes (sticks, pads, triggers, gyro sensors)
- Keyboard key selection uses the existing `KeyboardUtils` and `FontEnumMapper` for consistent key naming and display
- Full serialization support ensures axis keyboard mappings persist across application sessions
- The UI follows the existing design pattern used for button and axis mappings with icon fonts and dark theme styling